### PR TITLE
feat: add ability to disable plugins at file-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,19 @@ svelteMarkdown({
 })
 ```
 
+Also, plugins can be disabled at the **file-level**:
+
+```markdown
+---
+title: Page title
+plugins:
+  remark: false # Disables remark plugins for this file only
+  rehype: false # Disables rehype plugins for this file only
+---
+
+Content...
+```
+
 ### layouts
 
 - Type: `Record<string, Layout>`

--- a/packages/svelte-markdown/src/compile/index.ts
+++ b/packages/svelte-markdown/src/compile/index.ts
@@ -59,6 +59,9 @@ export async function compile(
     }
   }
 
+  if (data.frontmatter?.plugins?.remark === false) data.plugins!.remark = []
+  if (data.frontmatter?.plugins?.rehype === false) data.plugins!.rehype = []
+
   const processed = await unified()
     .use(remarkParse)
     .use(remarkSvelteHtml)

--- a/packages/svelte-markdown/src/compile/types/frontmatter.ts
+++ b/packages/svelte-markdown/src/compile/types/frontmatter.ts
@@ -23,4 +23,15 @@ export type Frontmatter = Record<string, unknown> & {
    * @default undefined
    */
   specialElements?: boolean
+  /**
+   * Specifies at the **file-level** whether plugins will be used or not.
+   *
+   * Useful if you want to completely disable plugins in a specific markdown file.
+   *
+   * @default undefined
+   */
+  plugins?: {
+    remark?: false
+    rehype?: false
+  }
 }


### PR DESCRIPTION

## Type of Change

- [x] New feature
- [x] Documentation

## Request Description

Specifies at the **file-level** whether plugins will be used or not.

Useful if you want to completely disable plugins in a specific markdown file.

```markdown
---
title: Page title
plugins:
  remark: false # Disables remark plugins for this file only
  rehype: false # Disables rehype plugins for this file only
---

Content...
```
