### PR TITLE
feat: introduce new markdown component syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,32 @@ title: Page Title
 
 <Component />
 
+<Component prop="data" />
+
+<Component>
+Children content
+</Component>
+
+Content...
+```
+
+```markdown
+---
+title: Page Title
+---
+
+<script lang="ts">
+  import { Component } from '$lib/components'
+</script>
+
+::Component
+
+::Component prop="data"
+
+::Component
+Children content
+::
+
 Content...
 ```
 

--- a/packages/svelte-markdown/src/plugins/internal/remark/html.ts
+++ b/packages/svelte-markdown/src/plugins/internal/remark/html.ts
@@ -6,6 +6,26 @@ import type { Plugin } from '@/plugins/types'
 const rgxSvelteBlock = /{[#:/@]\w+.*}/
 const rgxElementOrComponent = /<[A-Za-z]+[\s\S]*>/
 
+const convertToComponent = (value: string): string => {
+  const tagMatch = value.match(/^::(\S+)/)
+  if (!tagMatch) return value
+
+  const tagName = tagMatch[1]
+  const isBlock = value.match(/::\s*$/)
+  const attrs =
+    value
+      .slice(tagName.length + 2)
+      .split('\n')[0]
+      .trim() || ''
+
+  if (isBlock) {
+    const content = value.split('\n').slice(1, -1).join('\n').trim()
+    return `<${tagName} ${attrs}>${content}</${tagName}>`
+  }
+
+  return `<${tagName} ${attrs} />`
+}
+
 const convertToHtml = (node: Paragraph): void => {
   let value = ''
 
@@ -23,6 +43,12 @@ export const remarkSvelteHtml: Plugin<[], Root> = () => {
       const [child] = node.children
 
       if (child?.type !== 'text' && child?.type !== 'html') return CONTINUE
+
+      if (child.value.startsWith('::')) {
+        child.value = convertToComponent(child.value)
+        convertToHtml(node)
+        return SKIP
+      }
 
       if (
         rgxSvelteBlock.test(child.value) ||

--- a/playgrounds/sveltekit/src/routes/docs/+page.md
+++ b/playgrounds/sveltekit/src/routes/docs/+page.md
@@ -9,7 +9,7 @@ description: Get started with Svelte Markdown.
 
 {description}
 
-<MarkdownTitle />
+::MarkdownTitle
 
 ## Heading Level 2
 


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [x] Documentation

## Request Description

Introduces new `markdown` component syntax.

Adds the ability to quickly and easily write components in markdown files.

```markdown
---
title: Page Title
---

<script lang="ts">
  import { Component } from '$lib/components'
</script>

::Component

::Component prop="data"

::Component
Children content
::

Content...
```

### Self-closing

```markdown
::Component
```

Transforms to:

```html
<Component />
```

### With Props

```markdown
::Component prop="data"
```

Transforms to:

```html
<Component prop="data" />
```

### Block

```markdown
::Component prop="data"
Content
::
```

Transforms to:

```html
<Component prop="data">
Content
</Component>
```