### PR TITLE
feat: add new remark-toc plugin

### DIFF
--- a/packages/svelte-markdown/src/plugins/public/index.ts
+++ b/packages/svelte-markdown/src/plugins/public/index.ts
@@ -1,1 +1,1 @@
-//
+export * from './remark'

--- a/packages/svelte-markdown/src/plugins/public/remark/index.ts
+++ b/packages/svelte-markdown/src/plugins/public/remark/index.ts
@@ -1,0 +1,1 @@
+export * from './toc'

--- a/packages/svelte-markdown/src/plugins/public/remark/toc/index.ts
+++ b/packages/svelte-markdown/src/plugins/public/remark/toc/index.ts
@@ -1,0 +1,86 @@
+import { visit } from 'unist-util-visit'
+import type { Root } from 'mdast'
+import type { Frontmatter } from '@/compile/types'
+import type { Plugin } from '@/plugins/types'
+import type { TocOptions, TocItems } from './types'
+
+/**
+ * A custom `Remark` plugin that creates `Table of Content` (Toc).
+ *
+ * Automatically adds a link with the appropriate attributes to the headings.
+ *
+ * It also stores Toc items to `frontmatter` for easy access.
+ *
+ * @example
+ *
+ * ```js
+ * import { remarkToc } from '@hypernym/svelte-markdown/plugins'
+ *
+ * svelteMarkdown({
+ *   plugins: {
+ *     remark: [remarkToc]
+ *   }
+ * })
+ * ```
+ *
+ * Or with options:
+ *
+ * ```js
+ * svelteMarkdown({
+ *   plugins: {
+ *     remark: [[remarkToc, { depth: 3 }]]
+ *   }
+ * })
+ * ```
+ *
+ */
+export const remarkToc: Plugin<[TocOptions?], Root> = (
+  options: TocOptions = {},
+) => {
+  const { depth = 3, links = true } = options
+
+  return (tree, vfile) => {
+    const frontmatter = vfile.data.frontmatter as Frontmatter & {
+      toc: TocItems
+    }
+
+    const toc: TocItems = []
+    let i = 0
+
+    visit(tree, 'heading', (node) => {
+      const [child] = node.children
+
+      let value = ''
+      let id = ''
+
+      if (child.type === 'text') {
+        value = child.value
+        id = value
+          .toLowerCase()
+          .replace(/[^a-z0-9\s-]/g, '')
+          .trim()
+          .replace(/\s+/g, '-')
+      }
+
+      if (links) {
+        node.children = []
+        node.children.push({
+          type: 'link',
+          url: `#${id}`,
+          children: [{ type: 'text', value }],
+        })
+      }
+
+      const data = node.data || (node.data = {})
+      const props = data.hProperties || (data.hProperties = {})
+
+      if (node.depth > 1 && node.depth <= depth) {
+        if (toc.some((h) => h.id === id)) id = `${id}-${i + 1}`
+        if (!props.id) props.id = id
+        toc.push({ id, depth: node.depth, value })
+      }
+    })
+
+    frontmatter.toc = toc
+  }
+}

--- a/packages/svelte-markdown/src/plugins/public/remark/toc/types.ts
+++ b/packages/svelte-markdown/src/plugins/public/remark/toc/types.ts
@@ -1,0 +1,22 @@
+export interface TocOptions {
+  /**
+   * Specifies the maximum headings depth to be included in the table of content.
+   *
+   * @default 3
+   */
+  depth?: number
+  /**
+   * Specifies whether headings include link tags.
+   *
+   * @default true
+   */
+  links?: boolean
+}
+
+export interface TocItem {
+  id: string
+  depth: number
+  value: string
+}
+
+export type TocItems = TocItem[]

--- a/packages/svelte-markdown/src/plugins/public/remark/types.ts
+++ b/packages/svelte-markdown/src/plugins/public/remark/types.ts
@@ -1,0 +1,3 @@
+export * from './toc/types'
+
+export * from './'

--- a/packages/svelte-markdown/src/plugins/public/types.ts
+++ b/packages/svelte-markdown/src/plugins/public/types.ts
@@ -12,3 +12,5 @@ export type * as Unified from 'unified'
 export type * as VFile from 'vfile'
 export type * as Mdast from 'mdast'
 export type * as Hast from 'hast'
+
+export * from './remark/types'


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Request Description

Adds new `remark-toc` plugin.

### remarkToc

A custom `Remark` plugin that creates `Table of Content` (Toc).

Automatically adds a link with the appropriate attributes to the headings.

It also stores Toc items to `frontmatter` for easy access.

```ts
import { remarkToc } from '@hypernym/svelte-markdown/plugins'

svelteMarkdown({
  plugins: {
    remark: [remarkToc],
  },
})
```

Or with options:

```ts
import { remarkToc } from '@hypernym/svelte-markdown/plugins'

svelteMarkdown({
  plugins: {
    remark: [[remarkToc, { depth: 3 }]],
  },
})
```

### Options

#### depth

- Type: `number`
- Default: `3`

Specifies the maximum headings depth to be included in the table of content.

#### links

- Type: `boolean`
- Default: `true`

Specifies whether headings include link tags.

### Usage

After plugin setup, you can access `Toc` via frontmatter:

```markdown
---
title: Blog page
description: Read the latest news.
---

## What's New

## Featured Posts

### Updates

### News

### Q&A

---

<ul>
  {#each frontmatter.toc as toc}
    <li><a href="#{toc.id}">{toc.value}</a></li>
  {/each}
</ul>
```

Generates:

```html
<h2 id="#whats-new"><a href="#whats-new">What's New</a></h2>
<h2 id="#featured-posts"><a href="#featured-posts">Featured Posts</a></h2>
<h3 id="#updates"><a href="#updates">Updates</a></h3>
<h3 id="#news"><a href="#news">News</a></h3>
<h3 id="#qa"><a href="#qa">Q&A</a></h3>

<hr />

<ul>
  <li><a href="#whats-new">What's New</a></li>
  <li><a href="#featured-posts">Featured Posts</a></li>
  <li><a href="#updates">Updates</a></li>
  <li><a href="#news">News</a></li>
  <li><a href="#qa">Q&A</a></li>
</ul>
```

Or you can pass `frontmatter.toc` as prop, if you already have toc component `<Toc data={frontmatter.toc} />`.

### frontmatter.toc

- Type: `TocItems`

```ts
interface TocItem {
  id: string
  depth: number
  value: string
}

type TocItems = TocItem[]
```

### Types

Also, types are exposed publicly, if you need easy access:

```ts
import type {
  TocItem,
  TocItems,
  TocOptions,
} from '@hypernym/svelte-markdown/plugins'
```
