### PR TITLE
feat: add new unique entries feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 
 - **Custom Components:** Simplifies development by supporting `import`/`export` of reusable components.
 - **Named Layouts:** Provides a powerful named `layout` mechanism to completely customize page design.
+- **Unique Entries:** Defines specialized, `entry-level` configuration adapted for all markdown files.
 - **Unified Plugins:** Enables content transformation using widely-adopted tools like `remark` and `rehype`.
 - **Global Frontmatter:** Streamlines workflow by offering centralized options for markdown `metadata`.
 - **Special Elements:** Supports parsing Svelte special elements such as `svelte:head` etc. in markdown files.
@@ -246,6 +247,25 @@ Content...
 ```markdown
 ---
 layout: false
+---
+
+Content...
+```
+
+### Unique Entries
+
+```markdown
+---
+title: Page Title
+entry: blog
+---
+
+Content...
+```
+
+```markdown
+---
+entry: false
 ---
 
 Content...
@@ -514,6 +534,8 @@ svelteMarkdown({
 
 Specifies the **top-level** plugins that will be used for all markdown files.
 
+- **Lifecycle:** `plugins` → `layout.plugins` → `entry.plugins`
+
 ```ts
 svelteMarkdown({
   plugins: {
@@ -544,6 +566,8 @@ Content...
 Specifies a custom layout records.
 
 Layout component serves as a wrapper for the markdown files, which means the page content is displayed via the component's children prop.
+
+- **Lifecycle:** `plugins` → `layout.plugins` → `entry.plugins`
 
 ```ts
 svelteMarkdown({
@@ -597,6 +621,72 @@ svelteMarkdown({
   frontmatter: {
     defaults: {
       layout: 'default',
+    },
+  },
+})
+```
+
+### entries
+
+- Type: `Record<string, Entry>`
+- Default: `undefined`
+
+Specifies a custom entry records.
+
+Entry serves as a special configuration for markdown files, which means it is similar to layout but without the need to create a custom component file.
+
+Allows unique and straightforward customization for an individual markdown file. An entry can be a page or a component.
+
+- **Lifecycle:** `plugins` → `layout.plugins` → `entry.plugins`
+
+```ts
+svelteMarkdown({
+  entries: {
+    blog: {
+      plugins: {
+        remark: [], // Specifies custom `remark` plugins at the entry-level (optional).
+        rehype: [], // Specifies custom `rehype` plugins at the entry-level (optional).
+      },
+    },
+  },
+})
+```
+
+Can be enabled at the **top-level** (via config) or at the **file-level** (via frontmatter).
+
+**File-level**
+
+```markdown
+---
+title: Page title
+entry: blog
+---
+
+Content...
+```
+
+Also, entry plugins can be disabled at the **file-level**:
+
+```markdown
+---
+title: Page title
+entry:
+  name: blog
+  plugins:
+    remark: false # Disables remark entry plugins for this file only
+    rehype: false # Disables rehype entry plugins for this file only
+---
+
+Content...
+```
+
+**Config**
+
+```ts
+svelteMarkdown({
+  frontmatter: {
+    defaults: {
+      entry: 'default',
     },
   },
 })

--- a/packages/svelte-markdown/src/compile/entries.ts
+++ b/packages/svelte-markdown/src/compile/entries.ts
@@ -1,0 +1,23 @@
+import { isObject } from '@/shared'
+import type { MarkdownConfig } from '@/config/types'
+import type { FileData, Entry } from './types'
+
+export function getEntryData(
+  data: FileData,
+  config: MarkdownConfig = {},
+): Entry | undefined {
+  const { entry } = data.frontmatter!
+
+  if (!config.entries || !entry) return
+
+  const entryName = isObject(entry) ? entry.name : entry
+
+  const entryConfig = config.entries[entryName]
+  if (!entryConfig) {
+    throw new TypeError(
+      `Invalid entry name. Valid names are: ${Object.keys(config.entries).join(', ')}.`,
+    )
+  }
+
+  return entryConfig
+}

--- a/packages/svelte-markdown/src/compile/index.ts
+++ b/packages/svelte-markdown/src/compile/index.ts
@@ -8,6 +8,7 @@ import rehypeStringify from 'rehype-stringify'
 import { meta, isFalse, isObject } from '@/shared'
 import { parseFile } from './file'
 import { getLayoutData } from './layouts'
+import { getEntryData } from './entries'
 import { createSvelteModule } from './module'
 import { createSvelteInstance } from './instance'
 import {
@@ -64,14 +65,28 @@ export async function compile(
     }
   }
 
+  const entry = getEntryData(data, config)
+  if (entry) {
+    if (entry.plugins && isObject(data.frontmatter?.entry)) {
+      if (isFalse(data.frontmatter?.entry?.plugins?.remark)) {
+        entry.plugins.remark = []
+      }
+      if (isFalse(data.frontmatter?.entry?.plugins?.rehype)) {
+        entry.plugins.rehype = []
+      }
+    }
+  }
+
   const processed = await unified()
     .use(remarkParse)
     .use(remarkSvelteHtml)
     .use(usePlugins(data.plugins?.remark))
     .use(usePlugins(layout?.plugins?.remark))
+    .use(usePlugins(entry?.plugins?.remark))
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(usePlugins(data.plugins?.rehype))
     .use(usePlugins(layout?.plugins?.rehype))
+    .use(usePlugins(entry?.plugins?.rehype))
     .use(rehypeRenderCode)
     .use(rehypeCreateLayout)
     .use(rehypeCreateComponents)

--- a/packages/svelte-markdown/src/compile/types/entries.ts
+++ b/packages/svelte-markdown/src/compile/types/entries.ts
@@ -1,0 +1,31 @@
+import type { PluginList } from '@/plugins/types'
+
+export interface Entry {
+  /**
+   * Specifies the **entry-specific** plugins that will only be applied to this particular markdown file.
+   *
+   * Also, these plugins will run after **top-level** and **layout-level** plugins.
+   *
+   * @default undefined
+   */
+  plugins?: {
+    /**
+     * Specifies custom `remark` plugins at the **entry-level**.
+     *
+     * Parses source into a Markdown AST (MDAST).
+     *
+     * @default undefined
+     */
+    remark?: PluginList
+    /**
+     * Specifies custom `rehype` plugins at the **entry-level**.
+     *
+     * Parses source into a HTML AST (HAST).
+     *
+     * @default undefined
+     */
+    rehype?: PluginList
+  }
+}
+
+export type Entries = Record<string, Entry>

--- a/packages/svelte-markdown/src/compile/types/frontmatter.ts
+++ b/packages/svelte-markdown/src/compile/types/frontmatter.ts
@@ -6,6 +6,27 @@ export type Frontmatter = Record<string, unknown> & {
    */
   defaults?: Record<string, unknown>
   /**
+   * Specifies support for parsing Svelte `special` elements such as `svelte:head` etc. in markdown files.
+   *
+   * Can be enabled at the **top-level** (via config) or at the **file-level** (via frontmatter).
+   *
+   * If you don't plan to use them in every markdown file, it is recommended to enable the option only on those pages where you really need it.
+   *
+   * @default undefined
+   */
+  specialElements?: boolean
+  /**
+   * Specifies at the **file-level** whether plugins will be used or not.
+   *
+   * Useful if you want to completely disable plugins in a specific markdown file.
+   *
+   * @default undefined
+   */
+  plugins?: {
+    remark?: false
+    rehype?: false
+  }
+  /**
    * Specifies layout name.
    *
    * To disable the layout, simply set it to `layout: false`.
@@ -27,24 +48,22 @@ export type Frontmatter = Record<string, unknown> & {
         }
       }
   /**
-   * Specifies support for parsing Svelte `special` elements such as `svelte:head` etc. in markdown files.
+   * Specifies entry name.
    *
-   * Can be enabled at the **top-level** (via config) or at the **file-level** (via frontmatter).
+   * Also, it is possible to specify at the **file-level** whether entry plugins will be used or not.
    *
-   * If you don't plan to use them in every markdown file, it is recommended to enable the option only on those pages where you really need it.
-   *
-   * @default undefined
-   */
-  specialElements?: boolean
-  /**
-   * Specifies at the **file-level** whether plugins will be used or not.
-   *
-   * Useful if you want to completely disable plugins in a specific markdown file.
+   * Useful if you want to completely disable entry plugins in a specific markdown file.
    *
    * @default undefined
    */
-  plugins?: {
-    remark?: false
-    rehype?: false
-  }
+  entry?:
+    | string
+    | false
+    | {
+        name: string
+        plugins?: {
+          remark?: false
+          rehype?: false
+        }
+      }
 }

--- a/packages/svelte-markdown/src/compile/types/index.ts
+++ b/packages/svelte-markdown/src/compile/types/index.ts
@@ -1,5 +1,6 @@
 export * from './file'
 export * from './frontmatter'
 export * from './layouts'
-export * from './compile'
+export * from './entries'
 export * from './highlight'
+export * from './compile'

--- a/packages/svelte-markdown/src/config/types.ts
+++ b/packages/svelte-markdown/src/config/types.ts
@@ -1,6 +1,6 @@
 import type { PreprocessorGroup } from 'svelte/compiler'
 import type { PluginList } from '@/plugins/types'
-import type { Layouts, Highlight } from '@/compile/types'
+import type { Layouts, Entries, Highlight } from '@/compile/types'
 
 export interface MarkdownConfig {
   /**
@@ -15,6 +15,37 @@ export interface MarkdownConfig {
    * @default undefined
    */
   preprocessors?: PreprocessorGroup[]
+  /**
+   * Defines frontmatter custom options.
+   *
+   * By default, frontmatter only supports the `YAML` format, but allows additional customization via parser.
+   *
+   * @default undefined
+   */
+  frontmatter?: {
+    /**
+     * Specifies frontmatter global data to be applied to all markdown files.
+     *
+     * @default undefined
+     */
+    defaults?: Record<string, unknown>
+    /**
+     * Specifies the **start/end** symbols for the frontmatter content block.
+     *
+     * It only works in combination with the default parser.
+     *
+     * @default '-'
+     */
+    marker?: string
+    /**
+     * Specifies a custom parser for frontmatter.
+     *
+     * Allows adaptation to other formats such as `TOML` or `JSON`.
+     *
+     * @default undefined
+     */
+    parser?: (value: string) => Record<string, unknown> | void
+  }
   /**
    * Specifies the **top-level** plugins that will be used for all markdown files.
    *
@@ -49,36 +80,17 @@ export interface MarkdownConfig {
    */
   layouts?: Layouts
   /**
-   * Defines frontmatter custom options.
+   * Specifies a custom entry records.
    *
-   * By default, frontmatter only supports the `YAML` format, but allows additional customization via parser.
+   * Entry serves as a special configuration for markdown files, which means it is similar to layout but without the need to create a custom component file.
+   *
+   * Allows unique and straightforward customization for an individual markdown file. An entry can be a page or a component.
+   *
+   * Can be enabled at the **top-level** (via config) or at the **file-level** (via frontmatter).
    *
    * @default undefined
    */
-  frontmatter?: {
-    /**
-     * Specifies frontmatter global data to be applied to all markdown files.
-     *
-     * @default undefined
-     */
-    defaults?: Record<string, unknown>
-    /**
-     * Specifies the **start/end** symbols for the frontmatter content block.
-     *
-     * It only works in combination with the default parser.
-     *
-     * @default '-'
-     */
-    marker?: string
-    /**
-     * Specifies a custom parser for frontmatter.
-     *
-     * Allows adaptation to other formats such as `TOML` or `JSON`.
-     *
-     * @default undefined
-     */
-    parser?: (value: string) => Record<string, unknown> | void
-  }
+  entries?: Entries
   /**
    * Defines custom syntax highlighting options.
    *

--- a/playgrounds/sveltekit/markdown.config.js
+++ b/playgrounds/sveltekit/markdown.config.js
@@ -1,5 +1,6 @@
 import { createHighlighter } from 'shiki'
 import { defineConfig } from '../../packages/svelte-markdown/dist/index.mjs'
+import { remarkToc } from '../../packages/svelte-markdown/dist/plugins/index.mjs'
 
 const theme = 'github-dark-default'
 const highlighter = await createHighlighter({
@@ -20,6 +21,13 @@ export const markdownConfig = defineConfig({
   layouts: {
     default: {
       path: 'src/content/layouts/default/layout.svelte',
+    },
+  },
+  entries: {
+    blog: {
+      plugins: {
+        remark: [remarkToc],
+      },
     },
   },
   highlight: {

--- a/playgrounds/sveltekit/src/components/header/NavMain.svelte
+++ b/playgrounds/sveltekit/src/components/header/NavMain.svelte
@@ -1,5 +1,6 @@
 <nav id="nav-main">
   <a href="/">Home</a>
   <a href="/about">About</a>
+  <a href="/blog">Blog</a>
   <a href="/docs">Docs</a>
 </nav>

--- a/playgrounds/sveltekit/src/routes/blog/+page.md
+++ b/playgrounds/sveltekit/src/routes/blog/+page.md
@@ -1,0 +1,24 @@
+---
+title: Blog page
+description: Read the latest news.
+layout: false
+entry: blog
+---
+
+## What's New
+
+## Featured Posts
+
+### Updates
+
+### News
+
+### Q&A
+
+---
+
+<ul>
+  {#each frontmatter.toc as toc}
+    <li><a href="#{toc.id}">{toc.value}</a></li>
+  {/each}
+</ul>


### PR DESCRIPTION

## Type of Change

- [x] New feature
- [x] Documentation

## Request Description

Adds new unique `entries` feature.

This feature is necessary if you have no needs for layouts but want to customize just one, two or more markdown files.

Super easy and powerful mechanism allows all sort of combination  layout and entry, top-level and entry etc.

For example, in the [playground](https://github.com/hypernym-studio/svelte-markdown/tree/main/playgrounds/sveltekit) we defined a `blog` entry that specifies `remarkToc` plugin for that particular page only. 

### entries

- Type: `Record<string, Entry>`
- Default: `undefined`

Specifies a custom entry records.

Entry serves as a special configuration for markdown files, which means it is similar to layout but without the need to create a custom component file.

Allows unique and straightforward customization for an individual markdown file. An entry can be a page or a component.

- **Lifecycle:** `plugins` → `layout.plugins` → `entry.plugins`

```ts
svelteMarkdown({
  entries: {
    blog: {
      plugins: {
        remark: [], // Specifies custom `remark` plugins at the entry-level (optional).
        rehype: [], // Specifies custom `rehype` plugins at the entry-level (optional).
      },
    },
  },
})
```

Can be enabled at the **top-level** (via config) or at the **file-level** (via frontmatter).

**File-level**

```markdown
---
title: Page title
entry: blog
---

Content...
```

Also, entry plugins can be disabled at the **file-level**:

```markdown
---
title: Page title
entry:
  name: blog
  plugins:
    remark: false # Disables remark entry plugins for this file only
    rehype: false # Disables rehype entry plugins for this file only
---

Content...
```

**Config**

```ts
svelteMarkdown({
  frontmatter: {
    defaults: {
      entry: 'default',
    },
  },
})
```